### PR TITLE
fix: load the seed file before every test suite and clean the database after every test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'builder'
 group :development, :test do
   gem 'rspec-rails'
   gem 'factory_girl_rails', require: false
+  gem 'database_cleaner'
 end
 
 gem 'therubyracer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
     compass-rails (1.1.7)
       compass (>= 0.12.2)
       sprockets (<= 2.11.0)
+    database_cleaner (1.4.1)
     devise (3.2.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -227,6 +228,7 @@ DEPENDENCIES
   capistrano-rails
   chosen-rails
   coffee-rails (~> 4.0.0)
+  database_cleaner
   devise
   dotenv-rails
   factory_girl_rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 require 'factory_girl_rails'
+require 'database_cleaner'
+DatabaseCleaner.strategy = :truncation
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -14,6 +16,14 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    load(Rails.root + "db/seeds.rb")
+  end
+
+  config.after(:suite) do
+    DatabaseCleaner.clean
+  end
+
   # ## Mock Framework
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:


### PR DESCRIPTION
The test suite doesn’t pass if you don’t load the seed file. This patch
loads the seed file before every suite run and cleans the database
after every suite run.