### PR TITLE
Enable manual selection of decks when adding results via API

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -68,7 +68,7 @@ class ResultsController < ApplicationController
   end
 
   def safe_params
-    params.require(:result).permit(:mode, :win, :hero, :opponent, :coin, :duration, :rank, :legend, :added)
+    params.require(:result).permit(:mode, :win, :hero, :opponent, :deck_name, :opponent_deck_name, :coin, :duration, :rank, :legend)
   end
 
   def deny_api_calls!

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -68,7 +68,7 @@ class ResultsController < ApplicationController
   end
 
   def safe_params
-    params.require(:result).permit(:mode, :win, :hero, :opponent, :deck_name, :opponent_deck_name, :coin, :duration, :rank, :legend)
+    params.require(:result).permit(:mode, :win, :hero, :opponent, :deck_name, :opponent_deck_name, :coin, :duration, :rank, :legend, :added)
   end
 
   def deny_api_calls!

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -17,6 +17,8 @@ class Result < ActiveRecord::Base
 
   has_many :tags
 
+  attr_accessor :deck_name, :opponent_deck_name
+
   scope :wins, ->{ where(win: true) }
   scope :losses, ->{ where(win: false) }
 
@@ -113,8 +115,18 @@ class Result < ActiveRecord::Base
   end
 
   def connect_to_decks
-    self.deck ||= determine_best_matching_player_deck
-    self.opponent_deck ||= determine_best_matching_opponent_deck
+    if self.deck_name.kind_of?(String)
+      self.deck = user.decks.where(name: self.deck_name).first
+    else
+      self.deck ||= determine_best_matching_player_deck
+    end
+
+    if self.opponent_deck_name.kind_of?(String)
+      self.opponent_deck = user.decks.where(name: self.opponent_deck_name).first
+    else
+      self.opponent_deck ||= determine_best_matching_opponent_deck
+    end
+
     self.save!
   end
 

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -125,9 +125,12 @@ describe Result do
     end
 
     context 'when deck names are specified manually via API' do
-      let(:result) {r = build_result 'Warlock', 'Rogue', me: player_cards_played, opponent: opponent_cards_played
-                      r.deck_name = 'demonlock'
-                      r }
+      let(:result) {
+        r = build_result 'Warlock', 'Rogue', me: player_cards_played, opponent: opponent_cards_played
+        r.deck_name = 'demonlock'
+        r
+      }
+
       it 'uses the specified deck' do
         expect { result.save! }.to change { result.deck }.to demonlock
       end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -123,6 +123,15 @@ describe Result do
         expect { result.save! }.to_not raise_error
       end
     end
+
+    context 'when deck names are specified manually via API' do
+      let(:result) {r = build_result 'Warlock', 'Rogue', me: player_cards_played, opponent: opponent_cards_played
+                      r.deck_name = 'demonlock'
+                      r }
+      it 'uses the specified deck' do
+        expect { result.save! }.to change { result.deck }.to demonlock
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Since I'm also facing issue #30 (I guess #48 is a duplicate by the way) while working on my iOS companion app (https://github.com/JulianEberius/track-o-bot-ios), I thought I'd give it a shot and contribute.

However, I'm not a Rails developer by trade, so I'm not sure these commits are very idiomatic. I tried translating deck names to deck objects in a deck=() method of the Result model as it is done for hero=(), but I could not figure out a way to access user or current_user in this context, so I now pass in deck names as transient (non-model) attributes and translate to deck objects in the already existing connect_to_decks() method where I can access the user context. There may be a more elegant way to do it.

Of course, this is only done if deck names are specified, if not the original method for determining the best matching deck is still used. I also added a basic RSpec.