### PR TITLE
Added ability to correct the rank when missed

### DIFF
--- a/app/assets/javascripts/history.js.coffee
+++ b/app/assets/javascripts/history.js.coffee
@@ -72,5 +72,32 @@ $(document).on 'ready page:load', ->
 
     false
 
+  $('.rank-edit-button').popover
+    html: true
+    placement: 'right'
+    content: ("<a href='#' data-rank='#{r}'><div class='ranks-rank#{r}' title='Rank #{r}'></div></a>" for r in [1..25]).join('')
+    trigger: 'focus'
+    template: '<div class="popover rank-edit-popover" role="tooltip"><div class="arrow"></div><div class="popover-content"></div></div>'
+
+  # Need to stop default behaviour, but popover will still show. Don't create
+  # popover here because it works not "normally" for multiple shows and unshows.
+  $('.rank-edit-button').click ->
+    false
+  
+  # When the popover is created (dynamically) is when we add callbacks to the
+  # rank pins. The elements don't exist until they're shown.
+  $('.rank-edit-button').on 'shown.bs.popover', ->
+    button = $(this)
+    $("#" + $(this).attr('aria-describedby') + " a").click ->
+      new_rank = $(this).data('rank')
+      $.ajax
+        type: 'PUT'
+        url: button.attr('href')
+        data:
+          result:
+            rank: new_rank
+        success: ->
+          button.parent().html("<div class='ranks-rank#{new_rank}' title='Rank #{new_rank}'></div>")
+
   loadContentForPopover '.card-history-button', 'click', placement: 'bottom'
   loadContentForPopover '.timeline-button', 'click', placement: 'bottom'

--- a/app/assets/stylesheets/history.css.scss
+++ b/app/assets/stylesheets/history.css.scss
@@ -108,6 +108,28 @@ table.history {
       line-height: 28px;
       text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
     }
+
+    .rank-edit-button {
+      text-align: center;
+      display: none;
+      width: 21px;
+      padding-top: 4px;
+    }
+
+    &:hover {
+      .rank-edit-button {
+        display: inline-block;
+      }
+    }
+
+    .rank-edit-popover {
+      max-width: 260px;
+      text-align: center;
+      .popover-content div {
+        display: inline-block;
+        margin: 1px 2px;
+      }
+    }
   }
   tr:hover {
     opacity: 1;

--- a/app/views/history/index.html.erb
+++ b/app/views/history/index.html.erb
@@ -60,7 +60,7 @@
               <% elsif result.rank && result.rank > 0 %>
                 <div class="ranks-rank<%= result.rank %>" title="Rank <%= result.rank %>"></div>
               <% else %>
-                &nbsp;
+                <%= link_to icon('cogs'), profile_result_path(result), title: "Set rank manually", class: 'rank-edit-button' %>
               <% end %>
             </td>
             <td class="timestamp <%= 'with-duration' if result.duration %>">


### PR DESCRIPTION
Sometimes the rank does not get recorded properly, provide a cog (similar to note
feature) that allows the user to select the (non-legend) rank the game took place
at.

Seems like a reasonably elegant solution to #63 