### PR TITLE
Generate more realistic-looking arena runs in seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -81,26 +81,63 @@ if Rails.env.development? && User.count == 0
   all_cards = Card.all
   all_heroes = Hero.all
 
-  100.times do |x|
-    mode = [:arena, :casual, :practice, :ranked].sample
-    result = Result.new(mode: mode,
-                  hero: all_heroes.sample,
-                  opponent: all_heroes.sample,
-                  win: [true, false].sample,
-                  coin: [true, false].sample,
-                  user: user,
-                  created_at: Date.today - rand(0..40).days
-                 )
-    result.rank = rand(1..25) if :ranked == mode
-    result.card_history_list = rand(2..10).times.map do |n|
+  generate_match = -> (turns, attributes) {
+    result = Result.new(attributes)
+    result.rank = rand(1..25) if result.ranked? && !result.rank
+    result.card_history_list = turns.times.map do |n|
       CardHistoryEntry.new(
         player: players[(n + (result.coin ? 1 : 0)) % 2],
         card: all_cards.sample,
         turn: n + 1
       )
     end
-    result.save
+    result.save!
+    result
+  }
+
+  100.times do
+    generate_match.(
+      rand(2..10),
+      mode: [:casual, :practice, :ranked].sample,
+      hero: all_heroes.sample,
+      opponent: all_heroes.sample,
+      win: [true, false].sample,
+      coin: [true, false].sample,
+      user: user,
+      created_at: Date.today - rand(0..40).days,
+    )
+  end
+
+  # Generate realistic-looking Arena runs
+  days = (1..40).to_a
+  30.times do
+    hero = all_heroes.sample
+    total_wins = rand(0..12)
+    total_losses = total_wins == 12 ? rand(0..2) : 3
+    total_matches = total_wins + total_losses
+    start_date = Date.today - days.delete(days.sample).days
+
+    wins = losses = 0
+    total_matches.times do |i|
+      total_turns = rand(2..10)
+      won = [true, false].sample
+      won = false if wins == total_wins
+      # Unless this is a 12-0 run, ensure that the final match is a loss:
+      won = true if total_losses == 3 && losses == 2 && i < total_matches-1
+
+      won ? (wins+=1) : (losses+=1)
+      start_date += total_turns.minutes
+
+      generate_match.(
+        total_turns,
+        mode: :arena,
+        hero: hero,
+        opponent: all_heroes.sample,
+        win: won,
+        coin: [true, false].sample,
+        user: user,
+        created_at: start_date,
+      )
+    end
   end
 end
-
-


### PR DESCRIPTION
The previous approach was too randomized, and thus arena entries were all generated with either 0 or 1 wins.

The new approach generates arena entries in a separate pass, and ensures:

- Entries have a realistic-looking win/loss ratio;
- 12-win runs can't have more than 2 losses;
- For runs with less than 12 wins, ensure that the final matchup is a loss.

This is a followup to #61

<img width="747" alt="screen shot 2016-09-16 at 3 33 47 pm" src="https://cloud.githubusercontent.com/assets/887/18587567/03d62d6c-7c23-11e6-8fa7-79bf3123fbbc.png">

<img width="740" alt="screen shot 2016-09-16 at 3 34 58 pm" src="https://cloud.githubusercontent.com/assets/887/18587604/297396c2-7c23-11e6-9822-16e7283a8483.png">
