### PR TITLE
Fix arena stats display bug

### DIFF
--- a/app/controllers/stats/arena_controller.rb
+++ b/app/controllers/stats/arena_controller.rb
@@ -4,6 +4,7 @@ class Stats::ArenaController < ApplicationController
   include Stats
 
   def index
+    @mode = :arena
     num_wins_per_arena = user_arenas
       .joins("LEFT JOIN results ON results.arena_id = arenas.id AND results.win = #{ActiveRecord::Base::connection.quote(true)}")
       .group('arenas.id')


### PR DESCRIPTION
A simple fix for #44. 

If you have a `mode` cookie set to anything besides 'all' or 'arena', then the arena stats controller would [use that cookie](https://github.com/stevschmid/trackobot.com/blob/master/app/controllers/concerns/stats.rb#L53) when it queried for `user_results`

By explicitly setting `@mode = :arena` in the arena stats controller, we simply skip pulling the mode from cookies. 