### PR TITLE
Added new meta decks for MSoG

### DIFF
--- a/db/decks.json
+++ b/db/decks.json
@@ -11,6 +11,10 @@
     {
       "key": "control",
       "name": "Control"
+    },
+    {
+      "key": "jade",
+      "name": "Jade"
     }
   ],
   "warlock": [
@@ -61,6 +65,10 @@
     {
       "key": "malygos",
       "name": "Malygos"
+    },
+    {
+      "key": "pirate",
+      "name": "Pirate"
     }
   ],
   "hunter": [
@@ -81,6 +89,10 @@
     {
       "key": "freeze",
       "name": "Freeze"
+    },
+    {
+      "key": "reno",
+      "name": "Reno"
     }
   ],
   "paladin": [
@@ -95,6 +107,14 @@
     {
       "key": "secret",
       "name": "Secret"
+    },
+    {
+      "key": "buff",
+      "name": "Buff"
+    },
+    {
+      "key": "murloc",
+      "name": "Murloc"
     }
   ],
   "druid": [
@@ -109,6 +129,10 @@
     {
       "key": "ramp",
       "name": "Ramp"
+    },
+    {
+      "key": "jade",
+      "name": "Jade"
     }
   ],
   "priest": [
@@ -127,6 +151,10 @@
     {
       "key": "cthun",
       "name": "C'Thun"
+    },
+    {
+      "key": "reno",
+      "name": "Reno"
     }
   ]
 }


### PR DESCRIPTION
Since lots of people keep asking for them, I've gone ahead and added the new archetypes. While the deck lists may not be fully stable yet, the archetypes are fairly well defined at this point. To ensure that they are at least playable, only decks that appear in the tempostorm snapshot have been added (i.e. no meme decks).